### PR TITLE
make leptos-rs/start work with "0.1.0-alpha"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ crate-type = ["cdylib", "rlib"]
 
 
 [dependencies]
-leptos = { git = "https://github.com/gbj/leptos", default-features = false, features = [
+leptos = { version = "0.1.0-alpha", default-features = false, features = [
   "serde",
 ] }
-leptos_meta = { git = "https://github.com/gbj/leptos", default-features = false }
-leptos_router = { git = "https://github.com/gbj/leptos", default-features = false }
+leptos_meta = { version = "0.1.0-alpha", default-features = false }
+leptos_router = { version = "0.1.0-alpha", default-features = false }
 
 gloo-net = { version = "0.2", features = ["http"] }
 log = "0.4"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2,7 +2,7 @@ use leptos::*;
 use leptos_meta::*;
 
 #[component]
-pub fn App(cx: Scope) -> Element {
+pub fn App(cx: Scope) -> impl IntoView {
     provide_context(cx, MetaContext::default());
 
     view! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ if #[cfg(feature = "hydrate")] {
 
       log!("hydrate mode - hydrating");
 
-      leptos::hydrate(body().unwrap(), move |cx| {
+      leptos::mount_to_body( move |cx| {
         view! { cx, <App/> }
       });
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -57,10 +57,10 @@ async fn render_app(req: HttpRequest) -> impl Responder {
             .chain(render_to_stream(move |cx| {
                 use_context::<MetaContext>(cx)
                     .map(|meta| meta.dehydrate())
-                    .unwrap_or_default()
+                    .unwrap_or_default().into_view(cx)
             }))
             .chain(futures::stream::once(async { HTML_MIDDLE.to_string() }))
-            .chain(render_to_stream(move |cx| app(cx).to_string()))
+            .chain(render_to_stream(move |cx| app(cx).into_view(cx)))
             .chain(futures::stream::once(async { HTML_END.to_string() }))
             .map(|html| Ok(web::Bytes::from(html)) as Result<web::Bytes>),
     )


### PR DESCRIPTION
The following changes make this starter work and compile with cargo-leptos 0.0.9 and leptos 0.1.0-alpha.