### PR TITLE
Make URL in log clickable in terminal

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -17,7 +17,7 @@ pub async fn run() -> std::io::Result<()> {
 
     simple_logger::init_with_level(log::Level::Debug).expect("couldn't initialize logging");
 
-    log::info!("serving at {addr}");
+    log::info!("serving at http://{addr}");
 
     let site_root = std::env::var("LEPTOS_SITE_ROOT").unwrap();
     let pkg_dir = std::env::var("LEPTOS_SITE_PKG_DIR").unwrap();


### PR DESCRIPTION
By adding `http://`, the `serving at` log entry gets a clickable link in your terminal app, as it is now recognized as a full URL. This helps in onboarding, as you save users just a few extra seconds during this process.