### PR TITLE
Change address in package.metadata.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ style-file = "style/main.scss"
 # Optional. Env: LEPTOS_ASSETS_DIR.
 assets-dir = "assets"
 # The IP and port (ex: 127.0.0.1:3000) where the server serves the content. Use it in your server setup.
-site-addr = "127.0.0.1:3000"
+site_address = "127.0.0.1:3000"
 # The port to use for automatic reload monitoring
 reload-port = 3001
 # [Optional] Command to use when running end2end tests. It will run in the end2end dir.


### PR DESCRIPTION
I was using this template and looks like I should change `site-addr` to `site_address`. Or I would get the 
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: ConfigError("missing field `site_address`")', src/main.rs:10:62
```