### PR TITLE
chore: Upgrade console_log to stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 actix-files = { version = "0.6", optional = true }
 actix-web = { version = "4", optional = true, features = ["macros"] }
 console_error_panic_hook = "0.1"
-console_log = "0.2"
+console_log = "1"
 cfg-if = "1"
 leptos = { version = "0.2", default-features = false, features = [
   "serde",


### PR DESCRIPTION
Following from https://github.com/leptos-rs/leptos/pull/724