### PR TITLE
Add optional `ssg` feature to template

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ leptos_router = { version = "0.3", default-features = false }
 wasm-bindgen = "0.2.84"
 
 [features]
+ssg = ["leptos/csr"]
 hydrate = ["leptos/hydrate", "leptos_meta/hydrate", "leptos_router/hydrate"]
 ssr = [
   "dep:actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ leptos_router = { version = "0.3", default-features = false }
 wasm-bindgen = "0.2.84"
 
 [features]
-ssg = ["leptos/csr"]
+ssg = ["leptos/csr", "leptos_meta/csr", "leptos_router/csr"]
 hydrate = ["leptos/hydrate", "leptos_meta/hydrate", "leptos_router/hydrate"]
 ssr = [
   "dep:actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ leptos_router = { version = "0.3", default-features = false }
 wasm-bindgen = "0.2.84"
 
 [features]
-ssg = ["leptos/csr", "leptos_meta/csr", "leptos_router/csr"]
+csr = ["leptos/csr", "leptos_meta/csr", "leptos_router/csr"]
 hydrate = ["leptos/hydrate", "leptos_meta/hydrate", "leptos_router/hydrate"]
 ssr = [
   "dep:actix-files",

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ LEPTOS_RELOAD_PORT="3001"
 Finally, run the server binary.
 
 ## Notes about SSG and Trunk:
-Although it is not recommended, you can also run your project without server integration using the feature `ssg` and `trunk serve`:
+Although it is not recommended, you can also run your project without server integration using the feature `csr` and `trunk serve`:
 
-`trunk serve --open --features ssg`
+`trunk serve --open --features csr`
 
 This may be useful for integrating external tools which require a static site, e.g. `tauri`.

--- a/README.md
+++ b/README.md
@@ -58,3 +58,10 @@ LEPTOS_SITE_ADDR="127.0.0.1:3000"
 LEPTOS_RELOAD_PORT="3001"
 ```
 Finally, run the server binary.
+
+## Notes about SSG and Trunk:
+Although it is not recommended, you can also run your project without server integration using the feature `ssg` and `trunk serve`:
+
+`trunk serve --open --features ssg`
+
+This may be useful for integrating external tools which require a static site, e.g. `tauri`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,9 +31,24 @@ async fn main() -> std::io::Result<()> {
     .await
 }
 
-#[cfg(not(feature = "ssr"))]
+#[cfg(all(not(feature = "ssr"), feature = "ssg"))]
 pub fn main() {
-    // no client-side main function
-    // unless we want this to work with e.g., Trunk for pure client-side testing
-    // see lib.rs for hydration function instead
+    /// ~~no client-side main function~~
+    /// ~~unless we want this to work with e.g., Trunk for pure client-side testing~~
+    /// ~~see lib.rs for hydration function instead~~
+
+		// a client-side main function is required for using `trunk serve`
+		// prefer using `cargo leptos serve` instead
+		// to run: `trunk serve --open --features ssg`
+		use leptos::*;
+		use leptos_start::app::*;
+		use wasm_bindgen::prelude::wasm_bindgen;
+
+		console_error_panic_hook::set_once();
+
+		leptos::mount_to_body(move |cx| {
+				// note: for testing it may be preferrable to replace this with a
+				// more specific component, although leptos_router should still work
+				view! {cx, <App/> }
+		});
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ async fn main() -> std::io::Result<()> {
     .await
 }
 
-#[cfg(not(any(feature = "ssr", feature = "ssg")))]
+#[cfg(not(any(feature = "ssr", feature = "csr")))]
 pub fn main() {
     // no client-side main function
     // unless we want this to work with e.g., Trunk for pure client-side testing
@@ -39,7 +39,7 @@ pub fn main() {
     // see optional feature `ssg` instead
 }
 
-#[cfg(all(not(feature = "ssr"), feature = "ssg"))]
+#[cfg(all(not(feature = "ssr"), feature = "csr"))]
 pub fn main() {
     // a client-side main function is required for using `trunk serve`
     // prefer using `cargo leptos serve` instead

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,12 +31,16 @@ async fn main() -> std::io::Result<()> {
     .await
 }
 
+#[cfg(not(any(feature = "ssr", feature = "ssg")))]
+pub fn main() {
+    // no client-side main function
+    // unless we want this to work with e.g., Trunk for pure client-side testing
+    // see lib.rs for hydration function instead
+		// see optional feature `ssg` instead
+}
+
 #[cfg(all(not(feature = "ssr"), feature = "ssg"))]
 pub fn main() {
-    /// ~~no client-side main function~~
-    /// ~~unless we want this to work with e.g., Trunk for pure client-side testing~~
-    /// ~~see lib.rs for hydration function instead~~
-
 		// a client-side main function is required for using `trunk serve`
 		// prefer using `cargo leptos serve` instead
 		// to run: `trunk serve --open --features ssg`

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,23 +36,23 @@ pub fn main() {
     // no client-side main function
     // unless we want this to work with e.g., Trunk for pure client-side testing
     // see lib.rs for hydration function instead
-		// see optional feature `ssg` instead
+    // see optional feature `ssg` instead
 }
 
 #[cfg(all(not(feature = "ssr"), feature = "ssg"))]
 pub fn main() {
-		// a client-side main function is required for using `trunk serve`
-		// prefer using `cargo leptos serve` instead
-		// to run: `trunk serve --open --features ssg`
-		use leptos::*;
-		use leptos_start::app::*;
-		use wasm_bindgen::prelude::wasm_bindgen;
+    // a client-side main function is required for using `trunk serve`
+    // prefer using `cargo leptos serve` instead
+    // to run: `trunk serve --open --features ssg`
+    use leptos::*;
+    use leptos_start::app::*;
+    use wasm_bindgen::prelude::wasm_bindgen;
 
-		console_error_panic_hook::set_once();
+    console_error_panic_hook::set_once();
 
-		leptos::mount_to_body(move |cx| {
-				// note: for testing it may be preferrable to replace this with a
-				// more specific component, although leptos_router should still work
-				view! {cx, <App/> }
-		});
+    leptos::mount_to_body(move |cx| {
+        // note: for testing it may be preferrable to replace this with a
+        // more specific component, although leptos_router should still work
+        view! {cx, <App/> }
+    });
 }


### PR DESCRIPTION
I want to use an external tool `Tauri` along with `Leptos`, and find it necessary to use `trunk serve` and `trunk build` for this purpose.
However, I had to manually add the logic on top of the starter template, which explicitly said: `no client-side main function unless we want this to work with Trunk`.

I believe that adding this feature will be helpful to those who are trying to mix `cargo Leptos serve` and `trunk serve` together