### PR TITLE
Upgrade to latest wasm-bindgen@0.2.86

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ leptos = { version = "0.3", default-features = false, features = [
 leptos_meta = { version = "0.3", default-features = false }
 leptos_actix = { version = "0.3", optional = true }
 leptos_router = { version = "0.3", default-features = false }
-wasm-bindgen = "=0.2.84"
+wasm-bindgen = "=0.2.86"
 
 [features]
 csr = ["leptos/csr", "leptos_meta/csr", "leptos_router/csr"]


### PR DESCRIPTION
to avoid issue with latest [cargo-leptos v0.1.10](https://github.com/leptos-rs/cargo-leptos/releases/tag/v0.1.10)

```bash
Error: at `~/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-leptos-0.1.10/src/compile/front.rs:46:30`

Caused by:
    0: at `~/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-leptos-0.1.10/src/compile/front.rs:111:10`
1: 
       
       it looks like the Rust project used to create this wasm file was linked against
       version of wasm-bindgen that uses a different bindgen format than this binary:
       
         rust wasm file schema version: 0.2.84
            this binary schema version: 0.2.86
       
       Currently the bindgen format is unstable enough that these two schema versions
       must exactly match. You can accomplish this by either updating this binary or 
       the wasm-bindgen dependency in the Rust project.
       
       You should be able to update the wasm-bindgen dependency with:
       
           cargo update -p wasm-bindgen --precise 0.2.86
       
       don't forget to recompile your wasm file! Alternatively, you can update the 
       binary with:
       
           cargo install -f wasm-bindgen-cli --version 0.2.84
       
       if this warning fails to go away though and you're not sure what to do feel free
       to open an issue at https://github.com/rustwasm/wasm-bindgen/issues!

```