### PR TITLE
upgrade Leptos to 0.5.0-beta

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ actix-web = { version = "4", optional = true, features = ["macros"] }
 console_error_panic_hook = "0.1"
 cfg-if = "1"
 http = { version = "0.2", optional = true }
-leptos = { version = "0.4", features = ["nightly"] }
-leptos_meta = { version = "0.4", features = ["nightly"] }
-leptos_actix = { version = "0.4", optional = true }
-leptos_router = { version = "0.4", features = ["nightly"] }
+leptos = { version = "0.5.0-beta", features = ["nightly"] }
+leptos_meta = { version = "0.5.0-beta", features = ["nightly"] }
+leptos_actix = { version = "0.5.0-beta", optional = true }
+leptos_router = { version = "0.5.0-beta", features = ["nightly"] }
 wasm-bindgen = "=0.2.87"
 
 [features]

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,11 +3,11 @@ use leptos_meta::*;
 use leptos_router::*;
 
 #[component]
-pub fn App(cx: Scope) -> impl IntoView {
+pub fn App() -> impl IntoView {
     // Provides context that manages stylesheets, titles, meta tags, etc.
-    provide_meta_context(cx);
+    provide_meta_context();
 
-    view! { cx,
+    view! {
         // injects a stylesheet into the document <head>
         // id=leptos means cargo-leptos will hot-reload this stylesheet
         <Stylesheet id="leptos" href="/pkg/leptos_start.css"/>
@@ -29,12 +29,12 @@ pub fn App(cx: Scope) -> impl IntoView {
 
 /// Renders the home page of your application.
 #[component]
-fn HomePage(cx: Scope) -> impl IntoView {
+fn HomePage() -> impl IntoView {
     // Creates a reactive value to update the button
-    let (count, set_count) = create_signal(cx, 0);
+    let (count, set_count) = create_signal(0);
     let on_click = move |_| set_count.update(|count| *count += 1);
 
-    view! { cx,
+    view! {
         <h1>"Welcome to Leptos!"</h1>
         <button on:click=on_click>"Click Me: " {count}</button>
     }
@@ -42,7 +42,7 @@ fn HomePage(cx: Scope) -> impl IntoView {
 
 /// 404 - Not Found
 #[component]
-fn NotFound(cx: Scope) -> impl IntoView {
+fn NotFound() -> impl IntoView {
     // set an HTTP status code 404
     // this is feature gated because it can only be done during
     // initial server-side rendering
@@ -53,11 +53,11 @@ fn NotFound(cx: Scope) -> impl IntoView {
     {
         // this can be done inline because it's synchronous
         // if it were async, we'd use a server function
-        let resp = expect_context::<leptos_actix::ResponseOptions>(cx);
+        let resp = expect_context::<leptos_actix::ResponseOptions>();
         resp.set_status(actix_web::http::StatusCode::NOT_FOUND);
     }
 
-    view! { cx,
+    view! {
         <h1>"Not Found"</h1>
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,8 @@ if #[cfg(feature = "hydrate")] {
 
       console_error_panic_hook::set_once();
 
-      leptos::mount_to_body(move |cx| {
-          view! { cx, <App/> }
+      leptos::mount_to_body(move || {
+          view! { <App/> }
       });
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ async fn main() -> std::io::Result<()> {
     let conf = get_configuration(None).await.unwrap();
     let addr = conf.leptos_options.site_addr;
     // Generate the list of routes in your Leptos App
-    let routes = generate_route_list(|cx| view! { cx, <App/> });
+    let routes = generate_route_list(|| view! { <App/> });
 
     HttpServer::new(move || {
         let leptos_options = &conf.leptos_options;
@@ -27,7 +27,7 @@ async fn main() -> std::io::Result<()> {
             .leptos_routes(
                 leptos_options.to_owned(),
                 routes.to_owned(),
-                |cx| view! { cx, <App/> },
+                || view! { <App/> },
             )
             .app_data(web::Data::new(leptos_options.to_owned()))
         //.wrap(middleware::Compress::default())
@@ -68,9 +68,9 @@ pub fn main() {
 
     console_error_panic_hook::set_once();
 
-    leptos::mount_to_body(move |cx| {
+    leptos::mount_to_body(move || {
         // note: for testing it may be preferrable to replace this with a
         // more specific component, although leptos_router should still work
-        view! {cx, <App/> }
+        view! { <App/> }
     });
 }


### PR DESCRIPTION
This is a template for getting started with Leptos `0.5.0-beta` and possibly `0.5.x`. Nothing else has changed, except for:
1. `Cargo.toml` - bump `leptos* ` version to `0.5.0-beta`
2.  Modified `cx` to match `0.5.0` pre-release note. [See here](https://github.com/leptos-rs/leptos/releases/tag/v0.5.0-beta)
 
- Usage
See [leptos/start](https://github.com/leptos-rs/start)