### PR TITLE
Specify toolchain Target to wasm32-unknown-unknown and remove empty 1st line of rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
-
 [toolchain]
 channel = "nightly"
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
# Changes
- Added `targets = ["wasm32-unknown-unknown"]` to `rust-toolchain.toml` as recommended in the [`nightly` Note](https://github.com/leptos-rs/leptos?tab=readme-ov-file#nightly-note) for an improved development experience
- Removed the first line of `rust-toolchain.toml` because it was empty

---

I hope, this change will improve the development experience, because the `wasm` target does not need to be specified and downloaded manually.
