### PR TITLE
Drop `watch` parameter from `package.metadata.leptos`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,8 +63,6 @@ end2end-cmd = "npx playwright test"
 end2end-dir = "end2end"
 #  The browserlist query used for optimizing the CSS.
 browserquery = "defaults"
-# Set by cargo-leptos watch when building with that tool. Controls whether autoreload JS will be included in the head
-watch = false
 # The environment Leptos will run in, usually either "DEV" or "PROD"
 env = "DEV"
 # The features to use when compiling the bin target


### PR DESCRIPTION
I don't know why this `watch` parameter is included here, is doing nothing. Was not included in the [beta two years ago](https://github.com/leptos-rs/cargo-leptos/tree/ba5172f323fec2ec1742c79bc39bdc96d5460326) nor currently exists and checking the blame of cargo-leptos, it was never included. 

Seems to be a mistake included by the commit https://github.com/leptos-rs/start/commit/6d83bbe669f9d9682d1ad9a25c0d53b15870be73

Perhaps would be good to warn about invalid metadata parameters when running cargo-leptos, opened https://github.com/leptos-rs/cargo-leptos/issues/266 to track it.