### PR TITLE
Remove unneeded imports in `main()` CSR

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -58,9 +58,7 @@ pub fn main() {
     // a client-side main function is required for using `trunk serve`
     // prefer using `cargo leptos serve` instead
     // to run: `trunk serve --open --features csr`
-    use leptos::*;
     use {{crate_name}}::app::*;
-    use wasm_bindgen::prelude::wasm_bindgen;
 
     console_error_panic_hook::set_once();
 


### PR DESCRIPTION
These imports are not needed. Were added in the first commit that implemented CSR in the template (https://github.com/leptos-rs/start/pull/21/commits/4032162a292ff32bf915bd1fe745585b66317d26) because was using the `view!` macro (altough I don't know why the wasm_bindgen prelude was added) and later the commit https://github.com/leptos-rs/start/commit/0012041c0189bd3cb1c9372b6a73cbdc7b62051f removed the need of importing `leptos::*`.

I'm getting the next warning:

```
warning: unused import: `wasm_bindgen::prelude::wasm_bindgen`
```