### PR TITLE
Add Sass cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ node_modules/
 test-results/
 end2end/playwright-report/
 playwright/.cache/
+
+# Sass cache dir
+.sass-cache/


### PR DESCRIPTION
I noticed the `.sass-cache` directory was appearing when I ran `git status` after building the template. However, this is a build artifact and should be ignored by git. Also see:

- https://github.com/github/gitignore/blob/main/Sass.gitignore
- https://stackoverflow.com/questions/14934800/why-does-sass-cache-folder-get-created

I figured this is probably happening in the other templates too, so I'll create PRs for them too.