### PR TITLE
Add a "nightly" option to the project generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ actix-files = { version = "0.6", optional = true }
 actix-web = { version = "4", optional = true, features = ["macros"] }
 console_error_panic_hook = "0.1"
 http = { version = "1.0.0", optional = true }
-leptos = { version = "0.6", features = ["nightly"] }
-leptos_meta = { version = "0.6", features = ["nightly"] }
+leptos = { version = "0.6"{% if nightly == "Yes" %}, features = ["nightly"]{% endif %} }
+leptos_meta = { version = "0.6"{% if nightly == "Yes" %}, features = ["nightly"]{% endif %} }
 leptos_actix = { version = "0.6", optional = true }
-leptos_router = { version = "0.6", features = ["nightly"] }
+leptos_router = { version = "0.6"{% if nightly == "Yes" %}, features = ["nightly"]{% endif %} }
 wasm-bindgen = "=0.2.92"
 
 [features]

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,0 +1,5 @@
+[placeholders]
+nightly = { prompt = "Use nightly features?", choices = ["No", "Yes"], default = "No", type = "string"}
+
+[conditional.'nightly == "No"']
+ignore = ["rust-toolchain.toml"]


### PR DESCRIPTION
This adds the "nightly" prompt to the project generation as it is already the case for the axum based starter.