### PR TITLE
Add --locked to cargo-leptos install in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is a template for use with the [Leptos](https://github.com/leptos-rs/leptos
 
 If you don't have `cargo-leptos` installed you can install it with
 
-`cargo install cargo-leptos`
+`cargo install cargo-leptos --locked`
 
 Then run
 


### PR DESCRIPTION
Cargo Leptos will not install on Windows without adding `--locked`. Updating readme accordingly.

See https://github.com/leptos-rs/cargo-leptos/issues/280 & https://github.com/leptos-rs/leptos/issues/2596